### PR TITLE
fix: fails on default podman installations 

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,5 +2,5 @@
   name: ShellCheck v0.8.0
   description: Static analysis tool for shell scripts
   language: docker_image
-  entry: koalaman/shellcheck:v0.8.0
+  entry: docker.io/koalaman/shellcheck:v0.8.0
   types: [shell]


### PR DESCRIPTION
This is a real quick one: on default podman installations (docker
drop-in-replacement by RedHat), like on Fedora Workstation, the pre-commit hook
fails due to the fact that podman by default prompts for input if container
short-names are used. It is safer and more inclusive to use the full container
registry path / name like `docker.io/koalaman/shellcheck:v0.8.0`.

I "fixed" this in my projects by using the following `.pre-commit-config.yml`:

```
- repo: https://github.com/koalaman/shellcheck-precommit
  rev: v0.8.0
  hooks:
    - id: shellcheck
      entry: docker.io/koalaman/shellcheck:v0.8.0
```

While you could take the position that podman is rather niche and this is
a project / host specific setting, I'd argue that you don't loose anything with
full container registry names while reducing problems on default podman
installations.